### PR TITLE
Echo.cpp: initialize samplerate

### DIFF
--- a/src/Effects/Echo.cpp
+++ b/src/Effects/Echo.cpp
@@ -29,6 +29,7 @@
 
 Echo::Echo(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize)
     :Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
+      samplerate(srate),
       Pvolume(50),
       Pdelay(60),
       Plrdelay(100),


### PR DESCRIPTION
Fixes crashing when loading any Zyn preset with Echo
