### PR TITLE
Fix for stuck notes resulting from reception of panic button or MIDI all-notes-off

### DIFF
--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1020,6 +1020,7 @@ void Part::ComputePartSmps()
         killallnotes = 0;
         for(int nefx = 0; nefx < NUM_PART_EFX; ++nefx)
             partefx[nefx]->cleanup();
+        monomemnotes.clear();
     }
     ctl.updateportamento();
 }


### PR DESCRIPTION
Fix for stuck notes resulting from reception of panic button or
MIDI all-notes-off when more than one note is active (note-off
not yet received) when in legato or mono mode.
