### PR TITLE
Rename all Effect classes to ZynEffect classes

### DIFF
--- a/src/Effects/Alienwah.cpp
+++ b/src/Effects/Alienwah.cpp
@@ -24,7 +24,7 @@
 #include "Alienwah.h"
 
 Alienwah::Alienwah(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize)
-    :Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
+    :ZynEffect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
       lfo(srate, bufsize),
       oldl(NULL),
       oldr(NULL)

--- a/src/Effects/Alienwah.h
+++ b/src/Effects/Alienwah.h
@@ -24,20 +24,20 @@
 #define ALIENWAH_H
 
 #include <complex>
-#include "Effect.h"
-#include "EffectLFO.h"
+#include "ZynEffect.h"
+#include "ZynEffectLFO.h"
 
 using namespace std;
 
 #define MAX_ALIENWAH_DELAY 100
 
-/**"AlienWah" Effect*/
-class Alienwah:public Effect
+/**"AlienWah" ZynEffect*/
+class Alienwah:public ZynEffect
 {
     public:
         /**
          * Constructor
-         * @param insertion_ true for insertion Effect
+         * @param insertion_ true for insertion ZynEffect
          * @param efxoutl_ Pointer to Alienwah's left channel output buffer
          * @param efxoutr_ Pointer to Alienwah's left channel output buffer
          * @return Initialized Alienwah
@@ -56,7 +56,7 @@ class Alienwah:public Effect
 
     private:
         //Alienwah Parameters
-        EffectLFO     lfo;      //lfo-ul Alienwah
+        ZynEffectLFO     lfo;      //lfo-ul Alienwah
         unsigned char Pvolume;
         unsigned char Pdepth;   //the depth of the Alienwah
         unsigned char Pfb;      //feedback

--- a/src/Effects/CMakeLists.txt
+++ b/src/Effects/CMakeLists.txt
@@ -4,9 +4,9 @@ set(zynaddsubfx_effect_SRCS
 	Effects/Distorsion.cpp
 	Effects/DynamicFilter.cpp
 	Effects/Echo.cpp
-	Effects/Effect.cpp
-	Effects/EffectLFO.cpp
-	Effects/EffectMgr.cpp
+	Effects/ZynEffect.cpp
+	Effects/ZynEffectLFO.cpp
+	Effects/ZynEffectMgr.cpp
 	Effects/EQ.cpp
 	Effects/Phaser.cpp
 	Effects/Reverb.cpp

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -27,7 +27,7 @@
 using namespace std;
 
 Chorus::Chorus(bool insertion_, float *const efxoutl_, float *efxoutr_, unsigned int srate, int bufsize)
-    :Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
+    :ZynEffect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
       lfo(srate, bufsize),
       maxdelay((int)(MAX_CHORUS_DELAY / 1000.0f * samplerate_f)),
       delaySample(new float[maxdelay], new float[maxdelay])

--- a/src/Effects/Chorus.h
+++ b/src/Effects/Chorus.h
@@ -22,14 +22,14 @@
 
 #ifndef CHORUS_H
 #define CHORUS_H
-#include "Effect.h"
-#include "EffectLFO.h"
+#include "ZynEffect.h"
+#include "ZynEffectLFO.h"
 #include "../Misc/Stereo.h"
 
 #define MAX_CHORUS_DELAY 250.0f //ms
 
 /**Chorus and Flange effects*/
-class Chorus:public Effect
+class Chorus:public ZynEffect
 {
     public:
         Chorus(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize);
@@ -85,7 +85,7 @@ class Chorus:public Effect
         unsigned char Pfb;         //feedback
         unsigned char Pflangemode; //how the LFO is scaled, to result chorus or flange
         unsigned char Poutsub;     //if I wish to substract the output instead of the adding it
-        EffectLFO     lfo;         //lfo-ul chorus
+        ZynEffectLFO     lfo;         //lfo-ul chorus
 
 
         //Parameter Controls

--- a/src/Effects/Distorsion.cpp
+++ b/src/Effects/Distorsion.cpp
@@ -26,7 +26,7 @@
 #include <cmath>
 
 Distorsion::Distorsion(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize)
-    :Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
+    :ZynEffect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
       Pvolume(50),
       Pdrive(90),
       Plevel(64),
@@ -75,7 +75,7 @@ void Distorsion::applyfilters(float *efxoutl, float *efxoutr)
 }
 
 
-//Effect output
+//ZynEffect output
 void Distorsion::out(const Stereo<float *> &smp)
 {
     float inputvol = powf(5.0f, (Pdrive - 32.0f) / 127.0f);

--- a/src/Effects/Distorsion.h
+++ b/src/Effects/Distorsion.h
@@ -1,7 +1,7 @@
 /*
   ZynAddSubFX - a software synthesizer
 
-  Distorsion.h - Distorsion Effect
+  Distorsion.h - Distorsion ZynEffect
   Copyright (C) 2002-2005 Nasca Octavian Paul
   Author: Nasca Octavian Paul
 
@@ -23,10 +23,10 @@
 #ifndef DISTORSION_H
 #define DISTORSION_H
 
-#include "Effect.h"
+#include "ZynEffect.h"
 
-/**Distortion Effect*/
-class Distorsion:public Effect
+/**Distortion ZynEffect*/
+class Distorsion:public ZynEffect
 {
     public:
         Distorsion(bool insertion, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize);

--- a/src/Effects/DynamicFilter.cpp
+++ b/src/Effects/DynamicFilter.cpp
@@ -25,7 +25,7 @@
 #include "../DSP/Filter.h"
 
 DynamicFilter::DynamicFilter(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize)
-    :Effect(insertion_, efxoutl_, efxoutr_, new FilterParams(0, 64, 64), 0, srate, bufsize),
+    :ZynEffect(insertion_, efxoutl_, efxoutr_, new FilterParams(0, 64, 64), 0, srate, bufsize),
       lfo(srate, bufsize),
       Pvolume(110),
       Pdepth(0),

--- a/src/Effects/DynamicFilter.h
+++ b/src/Effects/DynamicFilter.h
@@ -23,11 +23,11 @@
 #ifndef DYNAMICFILTER_H
 #define DYNAMICFILTER_H
 
-#include "Effect.h"
-#include "EffectLFO.h"
+#include "ZynEffect.h"
+#include "ZynEffectLFO.h"
 
-/**DynamicFilter Effect*/
-class DynamicFilter:public Effect
+/**DynamicFilter ZynEffect*/
+class DynamicFilter:public ZynEffect
 {
     public:
         DynamicFilter(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize);
@@ -41,7 +41,7 @@ class DynamicFilter:public Effect
 
     private:
         //Parametrii DynamicFilter
-        EffectLFO     lfo;          //lfo-ul DynamicFilter
+        ZynEffectLFO     lfo;          //lfo-ul DynamicFilter
         unsigned char Pvolume;      //Volume
         unsigned char Pdepth;       //the depth of the lfo
         unsigned char Pampsns;      //how the filter varies according to the input amplitude

--- a/src/Effects/EQ.cpp
+++ b/src/Effects/EQ.cpp
@@ -25,7 +25,7 @@
 #include "../DSP/AnalogFilter.h"
 
 EQ::EQ(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize)
-    :Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize)
+    :ZynEffect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize)
 {
     for(int i = 0; i < MAX_EQ_BANDS; ++i) {
         filter[i].Ptype   = 0;
@@ -61,7 +61,7 @@ void EQ::cleanup(void)
     }
 }
 
-//Effect output
+//ZynEffect output
 void EQ::out(const Stereo<float *> &smp)
 {
     for(int i = 0; i < buffersize; ++i) {

--- a/src/Effects/EQ.h
+++ b/src/Effects/EQ.h
@@ -1,7 +1,7 @@
 /*
   ZynAddSubFX - a software synthesizer
 
-  EQ.h - EQ Effect
+  EQ.h - EQ ZynEffect
   Copyright (C) 2002-2005 Nasca Octavian Paul
   Author: Nasca Octavian Paul
 
@@ -23,10 +23,10 @@
 #ifndef EQ_H
 #define EQ_H
 
-#include "Effect.h"
+#include "ZynEffect.h"
 
-/**EQ Effect*/
-class EQ:public Effect
+/**EQ ZynEffect*/
+class EQ:public ZynEffect
 {
     public:
         EQ(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize);

--- a/src/Effects/Echo.cpp
+++ b/src/Effects/Echo.cpp
@@ -28,7 +28,7 @@
 #define MAX_DELAY 2
 
 Echo::Echo(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize)
-    :Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
+    :ZynEffect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
       samplerate(srate),
       Pvolume(50),
       Pdelay(60),
@@ -82,7 +82,7 @@ void Echo::initdelays(void)
     ndelta.r = max(1, (int) (dr * samplerate));
 }
 
-//Effect output
+//ZynEffect output
 void Echo::out(const Stereo<float *> &input)
 {
     for(int i = 0; i < buffersize; ++i) {

--- a/src/Effects/Echo.h
+++ b/src/Effects/Echo.h
@@ -1,7 +1,7 @@
 /*
   ZynAddSubFX - a software synthesizer
 
-  Echo.h - Echo Effect
+  Echo.h - Echo ZynEffect
   Copyright (C) 2002-2005 Nasca Octavian Paul
   Author: Nasca Octavian Paul
 
@@ -23,11 +23,11 @@
 #ifndef ECHO_H
 #define ECHO_H
 
-#include "Effect.h"
+#include "ZynEffect.h"
 #include "../Misc/Stereo.h"
 
-/**Echo Effect*/
-class Echo:public Effect
+/**Echo ZynEffect*/
+class Echo:public ZynEffect
 {
     public:
         Echo(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize);

--- a/src/Effects/Phaser.cpp
+++ b/src/Effects/Phaser.cpp
@@ -40,7 +40,7 @@ using namespace std;
 #define ZERO_ 0.00001f        // Same idea as above.
 
 Phaser::Phaser(const int &insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize)
-    :Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize), lfo(srate, bufsize), old(NULL), xn1(NULL),
+    :ZynEffect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize), lfo(srate, bufsize), old(NULL), xn1(NULL),
       yn1(NULL), diff(0.0f), oldgain(0.0f), fb(0.0f)
 {
     analog_setup();
@@ -93,7 +93,7 @@ Phaser::~Phaser()
 }
 
 /*
- * Effect output
+ * ZynEffect output
  */
 void Phaser::out(const Stereo<float *> &input)
 {

--- a/src/Effects/Phaser.h
+++ b/src/Effects/Phaser.h
@@ -27,12 +27,12 @@
 #ifndef PHASER_H
 #define PHASER_H
 #include "../globals.h"
-#include "Effect.h"
-#include "EffectLFO.h"
+#include "ZynEffect.h"
+#include "ZynEffectLFO.h"
 
 #define MAX_PHASER_STAGES 12
 
-class Phaser:public Effect
+class Phaser:public ZynEffect
 {
     public:
         Phaser(const int &insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize);
@@ -45,7 +45,7 @@ class Phaser:public Effect
 
     private:
         //Phaser parameters
-        EffectLFO     lfo;          //Phaser modulator
+        ZynEffectLFO     lfo;          //Phaser modulator
         unsigned char Pvolume;      //Used to set wet/dry mix
         unsigned char Pdistortion;  //Model distortion added by FET element
         unsigned char Pdepth;       //Depth of phaser sweep

--- a/src/Effects/Reverb.cpp
+++ b/src/Effects/Reverb.cpp
@@ -27,7 +27,7 @@
 #include <cmath>
 
 Reverb::Reverb(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize)
-    :Effect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
+    :ZynEffect(insertion_, efxoutl_, efxoutr_, NULL, 0, srate, bufsize),
       // defaults
       Pvolume(48),
       Ptime(64),
@@ -138,7 +138,7 @@ void Reverb::processmono(int ch, float *output, float *inputbuf)
     }
 }
 
-//Effect output
+//ZynEffect output
 void Reverb::out(const Stereo<float *> &smp)
 {
     if(!Pvolume && insertion)

--- a/src/Effects/Reverb.h
+++ b/src/Effects/Reverb.h
@@ -23,13 +23,13 @@
 #ifndef REVERB_H
 #define REVERB_H
 
-#include "Effect.h"
+#include "ZynEffect.h"
 
 #define REV_COMBS 8
 #define REV_APS 4
 
-/**Creates Reverberation Effects*/
-class Reverb:public Effect
+/**Creates Reverberation ZynEffects*/
+class Reverb:public ZynEffect
 {
     public:
         Reverb(bool insertion_, float *efxoutl_, float *efxoutr_, unsigned int srate, int bufsize);

--- a/src/Effects/ZynEffect.cpp
+++ b/src/Effects/ZynEffect.cpp
@@ -1,7 +1,7 @@
 /*
   ZynAddSubFX - a software synthesizer
 
-  Effect.cpp - this class is inherited by the all effects(Reverb, Echo, ..)
+  ZynEffect.cpp - this class is inherited by the all effects(Reverb, Echo, ..)
   Copyright (C) 2002-2005 Nasca Octavian Paul
   Copyright 2011, Alan Calvert
   Author: Nasca Octavian Paul
@@ -21,11 +21,11 @@
 
 */
 
-#include "Effect.h"
+#include "ZynEffect.h"
 #include "../Params/FilterParams.h"
 #include <cmath>
 
-Effect::Effect(bool insertion_, float *efxoutl_, float *efxoutr_,
+ZynEffect::ZynEffect(bool insertion_, float *efxoutl_, float *efxoutr_,
                FilterParams *filterpars_, unsigned char Ppreset_,
                unsigned int srate, int bufsize)
     :Ppreset(Ppreset_),
@@ -39,12 +39,12 @@ Effect::Effect(bool insertion_, float *efxoutl_, float *efxoutr_,
     alias();
 }
 
-void Effect::out(float *const smpsl, float *const smpsr)
+void ZynEffect::out(float *const smpsl, float *const smpsr)
 {
     out(Stereo<float *>(smpsl, smpsr));
 }
 
-void Effect::crossover(float &a, float &b, float crossover)
+void ZynEffect::crossover(float &a, float &b, float crossover)
 {
     float tmpa = a;
     float tmpb = b;
@@ -52,7 +52,7 @@ void Effect::crossover(float &a, float &b, float crossover)
     b = tmpb * (1.0f - crossover) + tmpa * crossover;
 }
 
-void Effect::setpanning(char Ppanning_)
+void ZynEffect::setpanning(char Ppanning_)
 {
     Ppanning = Ppanning_;
     float t = (Ppanning > 0) ? (float)(Ppanning - 1) / 126.0f : 0.0f;
@@ -60,7 +60,7 @@ void Effect::setpanning(char Ppanning_)
     pangainR = cosf((1.0f - t) * PI / 2.0f);
 }
 
-void Effect::setlrcross(char Plrcross_)
+void ZynEffect::setlrcross(char Plrcross_)
 {
     Plrcross = Plrcross_;
     lrcross  = (float)Plrcross / 127.0f;

--- a/src/Effects/ZynEffect.h
+++ b/src/Effects/ZynEffect.h
@@ -1,7 +1,7 @@
 /*
   ZynAddSubFX - a software synthesizer
 
-  Effect.h - this class is inherited by the all effects(Reverb, Echo, ..)
+  ZynEffect.h - this class is inherited by the all effects(Reverb, Echo, ..)
   Copyright (C) 2002-2005 Nasca Octavian Paul
   Author: Nasca Octavian Paul
 
@@ -31,21 +31,21 @@
 class FilterParams;
 
 /**this class is inherited by the all effects(Reverb, Echo, ..)*/
-class Effect
+class ZynEffect
 {
     public:
         /**
-         * Effect Constructor
-         * @param insertion_ 1 when it is an insertion Effect
-         * @param efxoutl_ Effect output buffer Left channel
-         * @param efxoutr_ Effect output buffer Right channel
+         * ZynEffect Constructor
+         * @param insertion_ 1 when it is an insertion ZynEffect
+         * @param efxoutl_ ZynEffect output buffer Left channel
+         * @param efxoutr_ ZynEffect output buffer Right channel
          * @param filterpars_ pointer to FilterParams array
          * @param Ppreset_ chosen preset
-         * @return Initialized Effect object*/
-        Effect(bool insertion_, float *efxoutl_, float *efxoutr_,
+         * @return Initialized ZynEffect object*/
+        ZynEffect(bool insertion_, float *efxoutl_, float *efxoutr_,
                FilterParams *filterpars_, unsigned char Ppreset_,
                unsigned int srate, int bufsize);
-        virtual ~Effect() {}
+        virtual ~ZynEffect() {}
         /**
          * Choose a preset
          * @param npreset number of chosen preset*/
@@ -63,7 +63,7 @@ class Effect
          *
          * This method should result in the effect generating its results
          * and placing them into the efxoutl and efxoutr buffers.
-         * Every Effect should overide this method.
+         * Every ZynEffect should overide this method.
          *
          * @param smpsl Input buffer for the Left channel
          * @param smpsr Input buffer for the Right channel
@@ -75,8 +75,8 @@ class Effect
         virtual float getfreqresponse(float freq) { return freq; }
 
         unsigned char Ppreset;   /**<Currently used preset*/
-        float *const  efxoutl; /**<Effect out Left Channel*/
-        float *const  efxoutr; /**<Effect out Right Channel*/
+        float *const  efxoutl; /**<ZynEffect out Left Channel*/
+        float *const  efxoutr; /**<ZynEffect out Right Channel*/
         float outvolume; /**<This is the volume of effect and is public because
                           * it is needed in system effects.
                           * The out volume of such effects are always 1.0f, so
@@ -85,7 +85,7 @@ class Effect
 
         float volume;
 
-        FilterParams *filterpars; /**<Parameters for filters used by Effect*/
+        FilterParams *filterpars; /**<Parameters for filters used by ZynEffect*/
 
         //Perform L/R crossover
         static void crossover(float &a, float &b, float crossover);

--- a/src/Effects/ZynEffectLFO.cpp
+++ b/src/Effects/ZynEffectLFO.cpp
@@ -1,7 +1,7 @@
 /*
   ZynAddSubFX - a software synthesizer
 
-  EffectLFO.cpp - Stereo LFO used by some effects
+  ZynEffectLFO.cpp - Stereo LFO used by some effects
   Copyright (C) 2002-2005 Nasca Octavian Paul
   Author: Nasca Octavian Paul
 
@@ -20,12 +20,12 @@
 
 */
 
-#include "EffectLFO.h"
+#include "ZynEffectLFO.h"
 #include "../Misc/Util.h"
 
 #include <cmath>
 
-EffectLFO::EffectLFO(float srate_f, float bufsize_f)
+ZynEffectLFO::ZynEffectLFO(float srate_f, float bufsize_f)
     :Pfreq(40),
       Prandomness(0),
       PLFOtype(0),
@@ -43,10 +43,10 @@ EffectLFO::EffectLFO(float srate_f, float bufsize_f)
     updateparams();
 }
 
-EffectLFO::~EffectLFO() {}
+ZynEffectLFO::~ZynEffectLFO() {}
 
 //Update the changed parameters
-void EffectLFO::updateparams(void)
+void ZynEffectLFO::updateparams(void)
 {
     float lfofreq = (powf(2.0f, Pfreq / 127.0f * 10.0f) - 1.0f) * 0.03f;
     incx = fabsf(lfofreq) * buffersize_f / samplerate_f;
@@ -64,11 +64,11 @@ void EffectLFO::updateparams(void)
 
 
 //Compute the shape of the LFO
-float EffectLFO::getlfoshape(float x)
+float ZynEffectLFO::getlfoshape(float x)
 {
     float out;
     switch(lfotype) {
-        case 1: //EffectLFO_TRIANGLE
+        case 1: //ZynEffectLFO_TRIANGLE
             if((x > 0.0f) && (x < 0.25f))
                 out = 4.0f * x;
             else
@@ -79,13 +79,13 @@ float EffectLFO::getlfoshape(float x)
             break;
         //when adding more, ensure ::updateparams() gets updated
         default:
-            out = cosf(x * 2.0f * PI); //EffectLFO_SINE
+            out = cosf(x * 2.0f * PI); //ZynEffectLFO_SINE
     }
     return out;
 }
 
 //LFO output
-void EffectLFO::effectlfoout(float *outl, float *outr)
+void ZynEffectLFO::effectlfoout(float *outl, float *outr)
 {
     float out;
 

--- a/src/Effects/ZynEffectLFO.h
+++ b/src/Effects/ZynEffectLFO.h
@@ -1,7 +1,7 @@
 /*
   ZynAddSubFX - a software synthesizer
 
-  EffectLFO.h - Stereo LFO used by some effects
+  ZynEffectLFO.h - Stereo LFO used by some effects
   Copyright (C) 2002-2005 Nasca Octavian Paul
   Author: Nasca Octavian Paul
 
@@ -23,13 +23,13 @@
 #ifndef EFFECT_LFO_H
 #define EFFECT_LFO_H
 
-/**LFO for some of the Effect objects
+/**LFO for some of the ZynEffect objects
  * \todo see if this should inherit LFO*/
-class EffectLFO
+class ZynEffectLFO
 {
     public:
-        EffectLFO(float srate_f, float bufsize_f);
-        ~EffectLFO();
+        ZynEffectLFO(float srate_f, float bufsize_f);
+        ~ZynEffectLFO();
         void effectlfoout(float *outl, float *outr);
         void updateparams(void);
         unsigned char Pfreq;

--- a/src/Effects/ZynEffectMgr.cpp
+++ b/src/Effects/ZynEffectMgr.cpp
@@ -1,7 +1,7 @@
 /*
   ZynAddSubFX - a software synthesizer
 
-  EffectMgr.cpp - Effect manager, an interface betwen the program and effects
+  ZynEffectMgr.cpp - ZynEffect manager, an interface betwen the program and effects
   Copyright (C) 2002-2005 Nasca Octavian Paul
   Author: Nasca Octavian Paul
 
@@ -20,8 +20,8 @@
 
 */
 
-#include "EffectMgr.h"
-#include "Effect.h"
+#include "ZynEffectMgr.h"
+#include "ZynEffect.h"
 #include "Reverb.h"
 #include "Echo.h"
 #include "Chorus.h"
@@ -34,7 +34,7 @@
 #include <iostream>
 using namespace std;
 
-EffectMgr::EffectMgr(const bool insertion_, pthread_mutex_t *mutex_)
+ZynEffectMgr::ZynEffectMgr(const bool insertion_, pthread_mutex_t *mutex_)
     :insertion(insertion_),
       efxoutl(new float[synth->buffersize]),
       efxoutr(new float[synth->buffersize]),
@@ -51,21 +51,21 @@ EffectMgr::EffectMgr(const bool insertion_, pthread_mutex_t *mutex_)
 }
 
 
-EffectMgr::~EffectMgr()
+ZynEffectMgr::~ZynEffectMgr()
 {
     delete efx;
     delete [] efxoutl;
     delete [] efxoutr;
 }
 
-void EffectMgr::defaults(void)
+void ZynEffectMgr::defaults(void)
 {
     changeeffect(0);
     setdryonly(false);
 }
 
 //Change the effect
-void EffectMgr::changeeffect(int _nefx)
+void ZynEffectMgr::changeeffect(int _nefx)
 {
     cleanup();
     if(nefx == _nefx)
@@ -110,13 +110,13 @@ void EffectMgr::changeeffect(int _nefx)
 }
 
 //Obtain the effect number
-int EffectMgr::geteffect(void)
+int ZynEffectMgr::geteffect(void)
 {
     return nefx;
 }
 
 // Cleanup the current effect
-void EffectMgr::cleanup(void)
+void ZynEffectMgr::cleanup(void)
 {
     if(efx)
         efx->cleanup();
@@ -124,7 +124,7 @@ void EffectMgr::cleanup(void)
 
 
 // Get the preset of the current effect
-unsigned char EffectMgr::getpreset(void)
+unsigned char ZynEffectMgr::getpreset(void)
 {
     if(efx)
         return efx->Ppreset;
@@ -133,14 +133,14 @@ unsigned char EffectMgr::getpreset(void)
 }
 
 // Change the preset of the current effect
-void EffectMgr::changepreset_nolock(unsigned char npreset)
+void ZynEffectMgr::changepreset_nolock(unsigned char npreset)
 {
     if(efx)
         efx->setpreset(npreset);
 }
 
 //Change the preset of the current effect(with thread locking)
-void EffectMgr::changepreset(unsigned char npreset)
+void ZynEffectMgr::changepreset(unsigned char npreset)
 {
     pthread_mutex_lock(mutex);
     changepreset_nolock(npreset);
@@ -149,7 +149,7 @@ void EffectMgr::changepreset(unsigned char npreset)
 
 
 //Change a parameter of the current effect
-void EffectMgr::seteffectpar_nolock(int npar, unsigned char value)
+void ZynEffectMgr::seteffectpar_nolock(int npar, unsigned char value)
 {
     if(!efx)
         return;
@@ -157,7 +157,7 @@ void EffectMgr::seteffectpar_nolock(int npar, unsigned char value)
 }
 
 // Change a parameter of the current effect (with thread locking)
-void EffectMgr::seteffectpar(int npar, unsigned char value)
+void ZynEffectMgr::seteffectpar(int npar, unsigned char value)
 {
     pthread_mutex_lock(mutex);
     seteffectpar_nolock(npar, value);
@@ -165,7 +165,7 @@ void EffectMgr::seteffectpar(int npar, unsigned char value)
 }
 
 //Get a parameter of the current effect
-unsigned char EffectMgr::geteffectpar(int npar)
+unsigned char ZynEffectMgr::geteffectpar(int npar)
 {
     if(!efx)
         return 0;
@@ -173,7 +173,7 @@ unsigned char EffectMgr::geteffectpar(int npar)
 }
 
 // Apply the effect
-void EffectMgr::out(float *smpsl, float *smpsr)
+void ZynEffectMgr::out(float *smpsl, float *smpsr)
 {
     if(!efx) {
         if(!insertion)
@@ -239,25 +239,25 @@ void EffectMgr::out(float *smpsl, float *smpsr)
 
 
 // Get the effect volume for the system effect
-float EffectMgr::sysefxgetvolume(void)
+float ZynEffectMgr::sysefxgetvolume(void)
 {
     return (!efx) ? 1.0f : efx->outvolume;
 }
 
 
 // Get the EQ response
-float EffectMgr::getEQfreqresponse(float freq)
+float ZynEffectMgr::getEQfreqresponse(float freq)
 {
     return (nefx == 7) ? efx->getfreqresponse(freq) : 0.0f;
 }
 
 
-void EffectMgr::setdryonly(bool value)
+void ZynEffectMgr::setdryonly(bool value)
 {
     dryonly = value;
 }
 
-void EffectMgr::add2XML(XMLwrapper *xml)
+void ZynEffectMgr::add2XML(XMLwrapper *xml)
 {
     xml->addpar("type", geteffect());
 
@@ -282,7 +282,7 @@ void EffectMgr::add2XML(XMLwrapper *xml)
     xml->endbranch();
 }
 
-void EffectMgr::getfromXML(XMLwrapper *xml)
+void ZynEffectMgr::getfromXML(XMLwrapper *xml)
 {
     changeeffect(xml->getpar127("type", geteffect()));
 

--- a/src/Effects/ZynEffectMgr.h
+++ b/src/Effects/ZynEffectMgr.h
@@ -1,7 +1,7 @@
 /*
   ZynAddSubFX - a software synthesizer
 
-  EffectMgr.h - Effect manager, an interface betwen the program and effects
+  ZynEffectMgr.h - ZynEffect manager, an interface betwen the program and effects
   Copyright (C) 2002-2005 Nasca Octavian Paul
   Author: Nasca Octavian Paul
 
@@ -28,7 +28,7 @@
 #include "Phaser.h"
 #include "../Params/Presets.h"
 
-class Effect;
+class ZynEffect;
 class FilterParams;
 class XMLwrapper;
 
@@ -39,12 +39,12 @@ class XMLwrapper;
 #include "../Params/FilterParams.h"
 #include "../Params/Presets.h"
 
-/**Effect manager, an interface betwen the program and effects*/
-class EffectMgr:public Presets
+/**ZynEffect manager, an interface betwen the program and effects*/
+class ZynEffectMgr:public Presets
 {
     public:
-        EffectMgr(const bool insertion_, pthread_mutex_t *mutex_);
-        ~EffectMgr();
+        ZynEffectMgr(const bool insertion_, pthread_mutex_t *mutex_);
+        ~ZynEffectMgr();
 
         void add2XML(XMLwrapper *xml);
         void defaults(void);
@@ -78,7 +78,7 @@ class EffectMgr:public Presets
 
     private:
         int     nefx;
-        Effect *efx;
+        ZynEffect *efx;
         pthread_mutex_t *mutex;
         bool dryonly;
 };

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -26,7 +26,7 @@
 #include "Part.h"
 
 #include "../Params/LFOParams.h"
-#include "../Effects/EffectMgr.h"
+#include "../Effects/ZynEffectMgr.h"
 #include "../DSP/FFTwrapper.h"
 
 #include <stdio.h>
@@ -68,13 +68,13 @@ Master::Master()
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
         part[npart] = new Part(&microtonal, fft, &mutex);
 
-    //Insertion Effects init
+    //Insertion ZynEffects init
     for(int nefx = 0; nefx < NUM_INS_EFX; ++nefx)
-        insefx[nefx] = new EffectMgr(1, &mutex);
+        insefx[nefx] = new ZynEffectMgr(1, &mutex);
 
-    //System Effects init
+    //System ZynEffects init
     for(int nefx = 0; nefx < NUM_SYS_EFX; ++nefx)
-        sysefx[nefx] = new EffectMgr(0, &mutex);
+        sysefx[nefx] = new ZynEffectMgr(0, &mutex);
 
 
     defaults();
@@ -98,7 +98,7 @@ void Master::defaults()
         Pinsparts[nefx] = -1;
     }
 
-    //System Effects init
+    //System ZynEffects init
     for(int nefx = 0; nefx < NUM_SYS_EFX; ++nefx) {
         sysefx[nefx]->defaults();
         for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
@@ -199,12 +199,12 @@ void Master::setController(char chan, int type, int par)
         if(ctl.getnrpn(&parhi, &parlo, &valhi, &vallo) == 0) //this is NRPN
             //fprintf(stderr,"rcv. NRPN: %d %d %d %d\n",parhi,parlo,valhi,vallo);
             switch(parhi) {
-                case 0x04: //System Effects
+                case 0x04: //System ZynEffects
                     if(parlo < NUM_SYS_EFX)
                         sysefx[parlo]->seteffectpar_nolock(valhi, vallo);
                     ;
                     break;
-                case 0x08: //Insertion Effects
+                case 0x08: //Insertion ZynEffects
                     if(parlo < NUM_INS_EFX)
                         insefx[parlo]->seteffectpar_nolock(valhi, vallo);
                     ;
@@ -400,7 +400,7 @@ void Master::AudioOut(float *outl, float *outr)
         memset(tmpmixl, 0, synth->bufferbytes);
         memset(tmpmixr, 0, synth->bufferbytes);
 
-        //Mix the channels according to the part settings about System Effect
+        //Mix the channels according to the part settings about System ZynEffect
         for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) {
             //skip if the part has no output to effect
             if(Psysefxvol[nefx][npart] == 0)
@@ -430,7 +430,7 @@ void Master::AudioOut(float *outl, float *outr)
 
         sysefx[nefx]->out(tmpmixl, tmpmixr);
 
-        //Add the System Effect to sound output
+        //Add the System ZynEffect to sound output
         const float outvol = sysefx[nefx]->sysefxgetvolume();
         for(int i = 0; i < synth->buffersize; ++i) {
             outl[i] += tmpmixl[i] * outvol;

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -133,8 +133,8 @@ class Master
         void setPsysefxsend(int Pefxfrom, int Pefxto, char Pvol);
 
         //effects
-        class EffectMgr * sysefx[NUM_SYS_EFX]; //system
-        class EffectMgr * insefx[NUM_INS_EFX]; //insertion
+        class ZynEffectMgr * sysefx[NUM_SYS_EFX]; //system
+        class ZynEffectMgr * insefx[NUM_INS_EFX]; //insertion
 //      void swapcopyeffects(int what,int type,int neff1,int neff2);
 
         //HDD recorder

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -24,7 +24,7 @@
 #include "Microtonal.h"
 #include "Util.h"
 #include "XMLwrapper.h"
-#include "../Effects/EffectMgr.h"
+#include "../Effects/ZynEffectMgr.h"
 #include "../Params/ADnoteParameters.h"
 #include "../Params/SUBnoteParameters.h"
 #include "../Params/PADnoteParameters.h"
@@ -56,9 +56,9 @@ Part::Part(Microtonal *microtonal_, FFTwrapper *fft_, pthread_mutex_t *mutex_)
     kit[0].subpars = new SUBnoteParameters();
     kit[0].padpars = new PADnoteParameters(fft, mutex);
 
-    //Part's Insertion Effects init
+    //Part's Insertion ZynEffects init
     for(int nefx = 0; nefx < NUM_PART_EFX; ++nefx) {
-        partefx[nefx]    = new EffectMgr(1, mutex);
+        partefx[nefx]    = new ZynEffectMgr(1, mutex);
         Pefxbypass[nefx] = false;
     }
 

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -32,7 +32,7 @@
 #include <pthread.h>
 #include <list> // For the monomemnotes list.
 
-class EffectMgr;
+class ZynEffectMgr;
 class ADnoteParameters;
 class SUBnoteParameters;
 class PADnoteParameters;
@@ -147,7 +147,7 @@ class Part
 
         Controller ctl; //Part controllers
 
-        EffectMgr    *partefx[NUM_PART_EFX]; //insertion part effects (they are part of the instrument)
+        ZynEffectMgr    *partefx[NUM_PART_EFX]; //insertion part effects (they are part of the instrument)
         unsigned char Pefxroute[NUM_PART_EFX]; //how the effect's output is routed(to next effect/to out)
         bool Pefxbypass[NUM_PART_EFX]; //if the effects are bypassed
 

--- a/src/Tests/EchoTest.h
+++ b/src/Tests/EchoTest.h
@@ -1,7 +1,7 @@
 /*
   ZynAddSubFX - a software synthesizer
 
-  EchoTest.h - CxxTest for Effect/Echo
+  EchoTest.h - CxxTest for ZynEffect/Echo
   Copyright (C) 2009-2011 Mark McCurry
   Copyright (C) 2009 Harald Hvaal
   Authors: Mark McCurry, Harald Hvaal

--- a/src/UI/EffUI.fl
+++ b/src/UI/EffUI.fl
@@ -30,7 +30,7 @@ decl {\#include "FilterUI.h"} {public
 decl {\#include "../Misc/Util.h"} {public
 } 
 
-decl {\#include "../Effects/EffectMgr.h"} {public
+decl {\#include "../Effects/ZynEffectMgr.h"} {public
 } 
 
 decl {\#include "PresetsUI.h"} {public
@@ -45,7 +45,7 @@ class EQGraph {: {public Fl_Box}
     code {eff=NULL;
 maxdB=30;} {}
   }
-  Function {init(EffectMgr *eff_)} {} {
+  Function {init(ZynEffectMgr *eff_)} {} {
     code {eff=eff_;
 oldx=-1;
 khzval=-1;} {}
@@ -158,7 +158,7 @@ return(log(freq/20.0)/log(1000.0));} {}
   decl {int oldx;} {}
   decl {float khzval;} {public
   }
-  decl {EffectMgr *eff;} {}
+  decl {ZynEffectMgr *eff;} {}
   decl {int maxdB;} {}
 } 
 
@@ -1281,7 +1281,7 @@ refresh(eff);}
       }
     }
   }
-  Function {init(EffectMgr *eff_)} {} {
+  Function {init(ZynEffectMgr *eff_)} {} {
     code {eff=eff_;
 
 make_null_window();
@@ -1309,7 +1309,7 @@ effdynamicfilterwindow->position(px,py);
 
 refresh(eff);} {}
   }
-  Function {refresh(EffectMgr *eff_)} {open
+  Function {refresh(ZynEffectMgr *eff_)} {open
   } {
     code {eff=eff_;
 this->hide();
@@ -1467,7 +1467,7 @@ this->show();} {}
   } {
     code {refresh(eff);} {}
   }
-  decl {EffectMgr *eff;} {}
+  decl {ZynEffectMgr *eff;} {}
   decl {int eqband;} {}
 } 
 
@@ -2215,7 +2215,7 @@ refresh(eff);}
       }
     }
   }
-  Function {init(EffectMgr *eff_)} {open
+  Function {init(ZynEffectMgr *eff_)} {open
   } {
     code {eff=eff_;
 
@@ -2244,7 +2244,7 @@ effdynamicfilterwindow->position(px,py);
 
 refresh(eff);} {}
   }
-  Function {refresh(EffectMgr *eff_)} {} {
+  Function {refresh(ZynEffectMgr *eff_)} {} {
     code {eff=eff_;
 this->hide();
 
@@ -2346,6 +2346,6 @@ this->show();} {}
   Function {refresh()} {} {
     code {refresh(eff);} {}
   }
-  decl {EffectMgr *eff;} {}
+  decl {ZynEffectMgr *eff;} {}
   decl {int eqband;} {}
 } 


### PR DESCRIPTION
I suddenly got tons of different segfaults with old zyn in `master`. Looking at gdb or gcc's address sanitizer, both say that `~Chorus()` of zyn calls `~Effect()` of LMMS (In Zyn, `Effect` is a base class of `Chorus`, but it's not the LMMS `Effect` class). Reason might be a new compiler or whatever.

This is a stupid fix I made solely with `sed -i`. It's not perfect, a few classes too much are replaced, but it works and this submodule here is only temporary until we have Lv2.

Note: minor changes in the LMMS main repo's CMakeLists are required (changing the file names there).

No testing or code/style review required. But I'd like someone to confirm that the commit makes sense.

Thanks on advance.