### PR TITLE
Update remote of submodule `instruments`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "instruments"]
 	path = instruments
-	url = git://git.code.sf.net/p/zynaddsubfx/instruments
+	url = https://github.com/zynaddsubfx/instruments


### PR DESCRIPTION
This PR

* updates the URL to use github (since SF is less reliable)
* changes the protocl from SSH to HTTPS (see https://stackoverflow.com/a/50299434)
* does not change the submodule's commit ID

You must now run
```
git submodule sync --recursive
```
once to reflect this change.