### PR TITLE
Made it so that AddSynth isn't lowpassed by default

### DIFF
--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -59,7 +59,7 @@ ADnoteGlobalParam::ADnoteGlobalParam()
     AmpEnvelope->ADSRinit_dB(0, 40, 127, 25);
     AmpLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 1);
 
-    GlobalFilter   = new FilterParams(2, 94, 40);
+    GlobalFilter   = new FilterParams(2, 127, 40);
     FilterEnvelope = new EnvelopeParams(0, 1);
     FilterEnvelope->ADSRinit_filter(64, 40, 64, 70, 60, 64);
     FilterLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 2);


### PR DESCRIPTION
I've made a slight change of setting the global AddSynth frequency from 94 to 127, so that the sound isn't lowpassed by default. It's a one line change I think would benefit users.