### PR TITLE
Filter frequency of all three synths set to 100

### DIFF
--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -59,7 +59,7 @@ ADnoteGlobalParam::ADnoteGlobalParam()
     AmpEnvelope->ADSRinit_dB(0, 40, 127, 25);
     AmpLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 1);
 
-    GlobalFilter   = new FilterParams(2, 127, 40);
+    GlobalFilter   = new FilterParams(2, 100, 40);
     FilterEnvelope = new EnvelopeParams(0, 1);
     FilterEnvelope->ADSRinit_filter(64, 40, 64, 70, 60, 64);
     FilterLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 2);

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -72,7 +72,7 @@ void Controller::resetall()
     setpitchwheel(0); //center
     setexpression(127);
     setpanning(64);
-    setfiltercutoff(64);
+    setfiltercutoff(127);
     setfilterq(64);
     setbandwidth(64);
     setmodwheel(64);

--- a/src/Params/PADnoteParameters.cpp
+++ b/src/Params/PADnoteParameters.cpp
@@ -43,7 +43,7 @@ PADnoteParameters::PADnoteParameters(FFTwrapper *fft_,
     AmpEnvelope->ADSRinit_dB(0, 40, 127, 25);
     AmpLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 1);
 
-    GlobalFilter   = new FilterParams(2, 94, 40);
+    GlobalFilter   = new FilterParams(2, 100, 40);
     FilterEnvelope = new EnvelopeParams(0, 1);
     FilterEnvelope->ADSRinit_filter(64, 40, 64, 70, 60, 64);
     FilterLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 2);

--- a/src/Params/SUBnoteParameters.cpp
+++ b/src/Params/SUBnoteParameters.cpp
@@ -35,7 +35,7 @@ SUBnoteParameters::SUBnoteParameters():Presets()
     BandWidthEnvelope = new EnvelopeParams(64, 0);
     BandWidthEnvelope->ASRinit_bw(100, 70, 64, 60);
 
-    GlobalFilter = new FilterParams(2, 80, 40);
+    GlobalFilter = new FilterParams(2, 100, 40);
     GlobalFilterEnvelope = new EnvelopeParams(0, 1);
     GlobalFilterEnvelope->ADSRinit_filter(64, 40, 64, 70, 60, 64);
 


### PR DESCRIPTION
To add to #22, the filter frequency of ADD, SUB and PAD have all been set to 100.

In LMMS, the filter frequency has been set to 127, the maximum value. This, according to Lost, allows for automating the filter as well as disabling the lowpass which happens by default.

The linked PR in LMMS is [here](https://github.com/LMMS/lmms/pull/7381).