### PR TITLE
WIN32 check for MSYS2 building

### DIFF
--- a/src/UI/common.H
+++ b/src/UI/common.H
@@ -20,6 +20,10 @@
 class Fl_Widget;
 extern void set_module_parameters ( Fl_Widget * );
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 #ifdef FLTK_GUI
 #define fl_color_add_alpha( x,y ) x 
 #undef FL_NO_BOX


### PR DESCRIPTION
MSYS2 building enables devs to build LMMS for Windows natively.

At the bottom of https://github.com/LMMS/lmms/issues/7526#issuecomment-2525061556, there are build commands that currently can build LMMS.

The `sed` command might be bit much, as there could be more and more changes that have to be made for the compilation to work in the future.

Instead of using `sed` from MSYS2, we could add a non-invasive `WIN32` check which adds the required header.