### PR TITLE
Revert of Zyn lowpass disabling

### DIFF
--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -59,7 +59,7 @@ ADnoteGlobalParam::ADnoteGlobalParam()
     AmpEnvelope->ADSRinit_dB(0, 40, 127, 25);
     AmpLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 1);
 
-    GlobalFilter   = new FilterParams(2, 100, 40);
+    GlobalFilter   = new FilterParams(2, 94, 40);
     FilterEnvelope = new EnvelopeParams(0, 1);
     FilterEnvelope->ADSRinit_filter(64, 40, 64, 70, 60, 64);
     FilterLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 2);

--- a/src/Params/PADnoteParameters.cpp
+++ b/src/Params/PADnoteParameters.cpp
@@ -43,7 +43,7 @@ PADnoteParameters::PADnoteParameters(FFTwrapper *fft_,
     AmpEnvelope->ADSRinit_dB(0, 40, 127, 25);
     AmpLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 1);
 
-    GlobalFilter   = new FilterParams(2, 100, 40);
+    GlobalFilter   = new FilterParams(2, 94, 40);
     FilterEnvelope = new EnvelopeParams(0, 1);
     FilterEnvelope->ADSRinit_filter(64, 40, 64, 70, 60, 64);
     FilterLfo = new LFOParams(80, 0, 64, 0, 0, 0, 0, 2);

--- a/src/Params/SUBnoteParameters.cpp
+++ b/src/Params/SUBnoteParameters.cpp
@@ -35,7 +35,7 @@ SUBnoteParameters::SUBnoteParameters():Presets()
     BandWidthEnvelope = new EnvelopeParams(64, 0);
     BandWidthEnvelope->ASRinit_bw(100, 70, 64, 60);
 
-    GlobalFilter = new FilterParams(2, 100, 40);
+    GlobalFilter = new FilterParams(2, 80, 40);
     GlobalFilterEnvelope = new EnvelopeParams(0, 1);
     GlobalFilterEnvelope->ADSRinit_filter(64, 40, 64, 70, 60, 64);
 


### PR DESCRIPTION
Reverts everything between e5c624212ab3a84f10b7029e1b0d90f999cba871 and d958c3668cc163805d581e97eb4d742168b6aad9.