### PR TITLE
Include headers from LMMS

### DIFF
--- a/src/Misc/Bank.cpp
+++ b/src/Misc/Bank.cpp
@@ -265,18 +265,17 @@ int Bank::newbank(string newbankdirname)
 
     // FIXME: Zyn should automatically handle creation of parent directory
 #ifdef WIN32
-    if(_wmkdir(lmms::toWString(bankdir).c_str()) < 0) return -1;
+    if(_wmkdir(lmms::toWString(bankdir).get()) < 0) { return -1; }
 #else
-    if(mkdir(bankdir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) return -1;
+    if(mkdir(bankdir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) { return -1; }
 #endif
 
     bankdir += newbankdirname;
 #ifdef WIN32
-    if(_wmkdir(lmms::toWString(bankdir).c_str()) < 0)
+    if(_wmkdir(lmms::toWString(bankdir).get()) < 0) { return -1; }
 #else
-    if(mkdir(bankdir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) < 0)
+    if(mkdir(bankdir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) < 0) { return -1; }
 #endif
-        return -1;
 
     const string tmpfilename = bankdir + '/' + FORCE_BANK_DIR_FILE;
 

--- a/src/Misc/IoHelper.h
+++ b/src/Misc/IoHelper.h
@@ -1,0 +1,121 @@
+/*
+ * IoHelper.h - helper functions for file I/O
+ *
+ * Copyright (c) 2018 Hyunjin Song <tteu.ingog/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_ZYN_IO_HELPER_H
+#define LMMS_ZYN_IO_HELPER_H
+
+#include <cstdio>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#ifdef _WIN32
+#	ifndef NOMINMAX
+#		define NOMINMAX
+#	endif
+#	include <windows.h>
+#endif
+
+#if defined(_WIN32) && !defined(__WINE__)
+#	include <io.h>
+#elif __has_include(<unistd.h>)
+#	include <unistd.h>
+#endif
+
+namespace lmms
+{
+
+
+#ifdef _WIN32
+
+/**
+ * UTF-8 to wide char conversion
+ * NOTE: Avoids using std::wstring because it does not work correctly with wineg++
+ */
+inline std::unique_ptr<wchar_t[]> toWString(std::string_view utf8)
+{
+	std::unique_ptr<wchar_t[]> ret;
+	if (utf8.empty())
+	{
+		ret = std::make_unique<wchar_t[]>(1);
+		return ret;
+	}
+
+	if (utf8.length() > static_cast<std::size_t>(std::numeric_limits<int>::max()))
+	{
+		throw std::overflow_error{"toWString: input string is too long"};
+	}
+	const auto utf8Len = static_cast<int>(utf8.length());
+
+	int result = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8.data(), utf8Len, nullptr, 0);
+	if (result <= 0)
+	{
+		const DWORD error = ::GetLastError();
+		throw std::invalid_argument{"toWString: failed to get size of result string. error code: " + std::to_string(error)};
+	}
+
+	ret = std::make_unique<wchar_t[]>(result);
+	result = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8.data(), utf8Len, ret.get(), result);
+	if (result <= 0)
+	{
+		const DWORD error = ::GetLastError();
+		throw std::invalid_argument{"toWString: failed to convert. error code: " + std::to_string(error)};
+	}
+
+	return ret;
+}
+
+#endif // _WIN32
+
+//! std::fopen wrapper that expects UTF-8 encoded `filename` and `mode`
+inline std::FILE* fopenUtf8(const std::string& filename, const char* mode)
+{
+#ifdef LMMS_BUILD_WIN32
+	return _wfopen(toWString(filename).get(), toWString(mode).get());
+#else
+	return std::fopen(filename.c_str(), mode);
+#endif
+}
+
+//! Returns the POSIX file descriptor of the given FILE
+inline int fileToDescriptor(std::FILE* file, bool closeFile = true)
+{
+	if (file == nullptr) { return -1; }
+
+#ifdef LMMS_BUILD_WIN32
+	int fh = _dup(_fileno(file));
+#else
+	int fh = dup(fileno(file));
+#endif
+
+	if (closeFile) { std::fclose(file); }
+	return fh;
+}
+
+
+} // namespace lmms
+
+#endif // LMMS_ZYN_IO_HELPER_H

--- a/src/Misc/IoHelper.h
+++ b/src/Misc/IoHelper.h
@@ -93,7 +93,7 @@ inline std::unique_ptr<wchar_t[]> toWString(std::string_view utf8)
 //! std::fopen wrapper that expects UTF-8 encoded `filename` and `mode`
 inline std::FILE* fopenUtf8(const std::string& filename, const char* mode)
 {
-#ifdef LMMS_BUILD_WIN32
+#if defined(_WIN32) && !defined(__WINE__)
 	return _wfopen(toWString(filename).get(), toWString(mode).get());
 #else
 	return std::fopen(filename.c_str(), mode);
@@ -105,7 +105,7 @@ inline int fileToDescriptor(std::FILE* file, bool closeFile = true)
 {
 	if (file == nullptr) { return -1; }
 
-#ifdef LMMS_BUILD_WIN32
+#if defined(_WIN32) && !defined(__WINE__)
 	int fh = _dup(_fileno(file));
 #else
 	int fh = dup(fileno(file));

--- a/src/Misc/IoHelper.h
+++ b/src/Misc/IoHelper.h
@@ -22,6 +22,9 @@
  *
  */
 
+// NOTE: The LMMS repo contains a copy of this header.
+//       If you modify this file, consider modifying it there as well.
+
 #ifndef LMMS_ZYN_IO_HELPER_H
 #define LMMS_ZYN_IO_HELPER_H
 
@@ -52,7 +55,7 @@ namespace lmms
 #ifdef _WIN32
 
 /**
- * UTF-8 to wide char conversion
+ * UTF-8 to wide string conversion
  * NOTE: Avoids using std::wstring because it does not work correctly with wineg++
  */
 inline std::unique_ptr<wchar_t[]> toWString(std::string_view utf8)

--- a/src/Misc/LocaleHelper.h
+++ b/src/Misc/LocaleHelper.h
@@ -25,6 +25,9 @@
  *
  */
 
+// NOTE: The LMMS repo contains a copy of this header.
+//       If you modify this file, consider modifying it there as well.
+
 #ifndef LMMS_ZYN_LOCALEHELPER_H
 #define LMMS_ZYN_LOCALEHELPER_H
 
@@ -36,7 +39,7 @@
 namespace lmms::LocaleHelper
 {
 
-inline double toDouble(QString str, bool* ok = nullptr)
+inline double toDouble(const QString& str, bool* ok = nullptr)
 {
 	bool isOkay;
 	QLocale c(QLocale::C);
@@ -48,16 +51,16 @@ inline double toDouble(QString str, bool* ok = nullptr)
 		german.setNumberOptions(QLocale::RejectGroupSeparator);
 		value = german.toDouble(str, &isOkay);
 	}
-	if (ok != nullptr) {*ok = isOkay;}
+	if (ok != nullptr) { *ok = isOkay; }
 	return value;
 }
 
-inline float toFloat(QString str, bool* ok = nullptr)
+inline float toFloat(const QString& str, bool* ok = nullptr)
 {
 	double d = toDouble(str, ok);
 	if (!std::isinf(d) && std::fabs(d) > std::numeric_limits<float>::max())
 	{
-		if (ok != nullptr) {*ok = false;}
+		if (ok != nullptr) { *ok = false; }
 		return 0.0f;
 	}
 	return static_cast<float>(d);

--- a/src/Misc/LocaleHelper.h
+++ b/src/Misc/LocaleHelper.h
@@ -1,0 +1,69 @@
+/*
+ * LocaleHelper.h - compatibility functions for handling decimal separators
+ * Providing helper functions which handle both periods and commas
+ * for decimal separators to load old projects correctly
+ *
+ * Copyright (c) 2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2018 Hyunjin Song <tteu.ingog/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_ZYN_LOCALEHELPER_H
+#define LMMS_ZYN_LOCALEHELPER_H
+
+#include <QLocale>
+
+#include <limits>
+#include <cmath>
+
+namespace lmms::LocaleHelper
+{
+
+inline double toDouble(QString str, bool* ok = nullptr)
+{
+	bool isOkay;
+	QLocale c(QLocale::C);
+	c.setNumberOptions(QLocale::RejectGroupSeparator);
+	double value = c.toDouble(str, &isOkay);
+	if (!isOkay)
+	{
+		QLocale german(QLocale::German);
+		german.setNumberOptions(QLocale::RejectGroupSeparator);
+		value = german.toDouble(str, &isOkay);
+	}
+	if (ok != nullptr) {*ok = isOkay;}
+	return value;
+}
+
+inline float toFloat(QString str, bool* ok = nullptr)
+{
+	double d = toDouble(str, ok);
+	if (!std::isinf(d) && std::fabs(d) > std::numeric_limits<float>::max())
+	{
+		if (ok != nullptr) {*ok = false;}
+		return 0.0f;
+	}
+	return static_cast<float>(d);
+}
+
+
+} // namespace lmms::LocaleHelper
+
+#endif // LMMS_ZYN_LOCALEHELPER_H

--- a/src/Misc/QtXmlWrapper.cpp
+++ b/src/Misc/QtXmlWrapper.cpp
@@ -57,8 +57,7 @@
 #include "../globals.h"
 #include "Util.h"
 
-// Include LMMS headers
-#include "lmmsconfig.h"
+// Include headers originally from LMMS
 #include "IoHelper.h"
 #include "LocaleHelper.h"
 

--- a/src/Misc/QtXmlWrapper.cpp
+++ b/src/Misc/QtXmlWrapper.cpp
@@ -196,7 +196,7 @@ int QtXmlWrapper::dosavefile(const char *filename,
                            int compression,
                            const char *xmldata) const
 {
-    FILE *file = lmms::F_OPEN_UTF8(std::string(filename), "w");
+    FILE *file = lmms::fopenUtf8(filename, "w");
     if(file == NULL) {
         return -1;
     }
@@ -318,7 +318,7 @@ char *QtXmlWrapper::doloadfile(const std::string &filename) const
 {
     char  *xmldata = NULL;
 
-    gzFile gzfile  = gzdopen(lmms::fileToDescriptor(lmms::F_OPEN_UTF8(filename, "rb")), "rb");
+    gzFile gzfile  = gzdopen(lmms::fileToDescriptor(lmms::fopenUtf8(filename, "rb")), "rb");
 
     if(gzfile != NULL) { //The possibly compressed file opened
         std::stringstream strBuf;             //reading stream


### PR DESCRIPTION
Due to the `IoHelper.h` changes from https://github.com/LMMS/lmms/pull/7916, this repo needed to be updated because it strangely depends on some headers from the LMMS/lmms repo for its own build.

I really didn't like that, so I've created a copy of `IoHelper.h` and `LocaleHelper.h` from LMMS/lmms to live here.
